### PR TITLE
[BugFix] Add Effects to Unowned Tokens

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   "styles": [
     "styles/inkpot.css"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "id": "inkpot-powerroll",
   "authors": [
     {

--- a/module/inkpot.js
+++ b/module/inkpot.js
@@ -42,4 +42,12 @@ Hooks.once('init', async function() {
       PowerRoll4e.onPowerRoll(event, undefined, undefined, app);
     });
   });
+
+  //Handle powerroll effect update requests that are being piped to a specific GM
+  Hooks.on("updateActor", (entity, data, options, userId) => {
+    PowerRoll4e.addEffectAsGM(entity, data, options, userId);
+  });
 });
+
+//remove any unprocessed effect requests
+Hooks.on("ready", () => PowerRoll4e.cleanAddEffectRequests());

--- a/module/powerroll4e.js
+++ b/module/powerroll4e.js
@@ -128,6 +128,40 @@ export class PowerRoll4e {
     button.disabled = false;
   }
 
+  /**
+   * This function is the current workaround due to users being unable to edit
+   * tokens they do not control.
+   *
+   * This function is called when the "updateActor" Hook is triggered. It
+   * expects the flag inkpot-powerroll to be set on a token the original user
+   * can control.
+   *
+   * The requested GM will add the effectDefinition document to the requested
+   * token.
+   * @param entity provided by updateActor Hook
+   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.gmId The id of the GM
+   *   that will add the effect.
+   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.sceneId The id of the
+   *   scene that the token is in.
+   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.tokenId The id of the
+   *   token that will gain the effect.
+   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.effectDefinition The
+   *   effect document that will be added to the token.
+   * @param options provided by updateActor Hook
+   * @param userId provided by updateActor Hook
+   */
+  static addEffectAsGM(entity, data, options, userId) {
+    PowerRollEffect4e.addEffectAsGM(entity, data, options, userId);
+  }
+
+  /**
+   * This function removes any lingering inkpot-powerroll flags that were not
+   * successfully processed.
+   */
+  static cleanAddEffectRequests() {
+    PowerRollEffect4e.cleanAddEffectRequests();
+  }
+
   static _createPowerRollUnknown(fullTxt, withoutBrackets) {
     const a = document.createElement('a');
     a.classList.add('power-roll');

--- a/module/powerrolls/effect.js
+++ b/module/powerrolls/effect.js
@@ -110,7 +110,50 @@ export class PowerRollEffect4e {
         });
       }
 
-      target.actor.createEmbeddedDocuments("ActiveEffect", [effectDefinition]);
+      if (target.isOwner) {
+        //directly update the effects if the current user owns the token
+        target.actor.createEmbeddedDocuments("ActiveEffect", [effectDefinition]);
+      } else {
+        // FoundryVTT does not allow users to edit tokens they do not own
+        // The following is a workaround and expects the user to have a default token and for the GM to be online
+        const defaultCharacter = game.user.character;
+        if (!defaultCharacter) {
+          ui.notifications.error("Error: You must set a default character.");
+          return;
+        }
+
+        const activeGMs = game.users.filter(u => u.isGM && u.active);
+        if (activeGMs.length == 0) {
+          ui.notifications.warn("Warning: Other tokens cannot be updated while the GM is away.");
+          return;
+        }
+
+        defaultCharacter.setFlag('inkpot-powerroll', Date.now(), {
+          gmId: activeGMs[0].id,
+          effectDefinition,
+          tokenId: target.id,
+          sceneId: target.scene.id
+        });
+      }
     });
+  }
+
+  static addEffectAsGM(entity, data, options, userId) {
+    const flagData = data?.flags?.['inkpot-powerroll'];
+    if(flagData === undefined) return;
+    const effectRequests = Object.entries(flagData).filter(([k, v]) => !isNaN(k));
+    if (effectRequests.length == 0) return;
+    const gmId = effectRequests.map(([k, v]) => v.gmId)[0];
+    if(game.user.id != gmId) return;
+    effectRequests.forEach(([k, v]) => game.scenes.get(v.sceneId).tokens.get(v.tokenId).actor.createEmbeddedDocuments("ActiveEffect", [v.effectDefinition]));
+    effectRequests.forEach(([k, v]) => entity.unsetFlag('inkpot-powerroll', k));
+  }
+
+  static cleanAddEffectRequests() {
+    const defaultCharacter = game.user.character;
+    if(!defaultCharacter) return;
+    Object.keys(defaultCharacter.flags['inkpot-powerroll'] || {})
+      .filter(k => !isNaN(k))
+      .forEach(k => defaultCharacter.unsetFlag('inkpot-powerroll', k));
   }
 }


### PR DESCRIPTION
## Problem

Players that tried to use the PowerRoll Effects feature to add an effect like "Prone" to a token they did not own would encounter an error from FoundryVTT. Fundamentally, FoundryVTT prevents users from editing tokens they do not own.

## Solution

Whenever a user tries to use PowerRoll Effects feature to add an effect to a token they do not own, the request will be piped to a GM user that is online. The GM user's client will fulfill the request. If no GM is currently online, the user will be told to wait until a GM is online.

The user should be entirely unaware that this is happening.

## Implementation

When a user attempts to add an effect to a token they own, the effect will be added immediately by the user's client.

When a user attempts to add an effect to a token they do not own, their client will check if a GM is online and warn the user if no GM is currently online. If an online GM is found, the user's client will record a request on the user's `game.user.character` in its flags.

```js
{
    ...
    flags: {
        ...
        inkpot-powerroll: {
            <UNIX_TIMESTAMP>: {
                gmId: <ID OF THE GM USER THAT WILL FULFILL THE REQUEST>,
                sceneId: <ID OF THE SCENE THAT THE TARGET TOKEN IS IN>,
                tokenId: <ID OF THE TARGET TOKENN>,
                effectDefinition: <EFFECT DOCUMENT THAT WILL BE ADDED TO THE TARGET TOKEN>
            }
        ...
    }
    ...
}
```

A hook on the GM user's client will see the flag being created on the original user's token, fulfill the request, and delete the successfully processed flag.

## Edge Case

There is an edge case of the user making a request as one of multiple GMs signs off. The user's client could see the signing off GM still logged on and happen to select that one GM to fulfill the request. By the time the GM user would have received the request, they are already signed off. The user will get no warning and a flag will linger on their default character. Further, the user would be confused as they attempted to add an effect on a token but nothing happened, even though there are still GMs logged on.

The user can try again, with the remaining GMs still logged on. A new request is made for a GM that is logged on, and the user will experience no further issues. That is to say, if it doesn't work, try again.

To prevent flags from building up due to unfulfilled requests, default tokens are cleaned of any lingering requests on their default character each time the user logs on.