### PR TITLE
[Bugfix] Effect Ids

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   "styles": [
     "styles/inkpot.css"
   ],
-  "version": "1.2.2",
+  "version": "1.2.3",
   "id": "inkpot-powerroll",
   "authors": [
     {
@@ -41,5 +41,6 @@
   "compatibility": {
     "minimum": "10",
     "verified": "10"
-  }
+  },
+  "socket": true
 }

--- a/module/inkpot.js
+++ b/module/inkpot.js
@@ -44,10 +44,5 @@ Hooks.once('init', async function() {
   });
 
   //Handle powerroll effect update requests that are being piped to a specific GM
-  Hooks.on("updateActor", (entity, data, options, userId) => {
-    PowerRoll4e.addEffectAsGM(entity, data, options, userId);
-  });
+  game.socket.on('module.inkpot-powerroll', PowerRoll4e.addEffectAsGM);
 });
-
-//remove any unprocessed effect requests
-Hooks.on("ready", () => PowerRoll4e.cleanAddEffectRequests());

--- a/module/powerroll4e.js
+++ b/module/powerroll4e.js
@@ -129,37 +129,16 @@ export class PowerRoll4e {
   }
 
   /**
-   * This function is the current workaround due to users being unable to edit
-   * tokens they do not control.
+   * A function called when requesting a GM to add an effect to a token.
    *
-   * This function is called when the "updateActor" Hook is triggered. It
-   * expects the flag inkpot-powerroll to be set on a token the original user
-   * can control.
-   *
-   * The requested GM will add the effectDefinition document to the requested
-   * token.
-   * @param entity provided by updateActor Hook
-   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.gmId The id of the GM
-   *   that will add the effect.
-   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.sceneId The id of the
-   *   scene that the token is in.
-   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.tokenId The id of the
-   *   token that will gain the effect.
-   * @param data.flags.inkpot-powerroll.UNIX_TIMESTAMP.effectDefinition The
-   *   effect document that will be added to the token.
-   * @param options provided by updateActor Hook
-   * @param userId provided by updateActor Hook
+   * @param options.gmId The id of the GM that will add the effect.
+   * @param options.sceneId The id of the scene that the token is in.
+   * @param options.tokenId The id of the token that will gain the effect.
+   * @param options.effectDefinition The effect document that will be added to
+   *   the token.
    */
-  static addEffectAsGM(entity, data, options, userId) {
-    PowerRollEffect4e.addEffectAsGM(entity, data, options, userId);
-  }
-
-  /**
-   * This function removes any lingering inkpot-powerroll flags that were not
-   * successfully processed.
-   */
-  static cleanAddEffectRequests() {
-    PowerRollEffect4e.cleanAddEffectRequests();
+  static addEffectAsGM(options) {
+    PowerRollEffect4e.addEffectAsGM(options);
   }
 
   static _createPowerRollUnknown(fullTxt, withoutBrackets) {


### PR DESCRIPTION
## Problem

Users would add a standard status effect such as prone with inkpot-powerroll. The user would then seek to toggle it off through the token while the Combat Utility Belt enhanced conditions feature was active. The toggle would add an extra prone effect. Only this extra prone effect would be toggleable. The original inkpot-powerroll prone effect could only be removed through the character sheet. 

## Solution

The bugfix looks up the id of standard status effects in `CONFIG.statusEffects`, preferring modified status ids first. If no modified status ids are found, use the normal status effect id.

## Note

Also updated change from PR #1 to use `game.socket` instead of `Hooks`. This is a cleaner approach that also uses less code.  