### PR TITLE
[Feature] Default Power Roll Costs

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   "styles": [
     "styles/inkpot.css"
   ],
-  "version": "1.2.3",
+  "version": "1.3.0",
   "id": "inkpot-powerroll",
   "authors": [
     {

--- a/module/config.js
+++ b/module/config.js
@@ -90,7 +90,9 @@ export class Config {
   ];
 
   static RESOURCE = {
-    'Augment': {'name': 'Power'}
+    'Augment': {'name': 'Power'},
+    'Channel Divinity': {'name': 'Channel Divinity'},
+    'Power \\S Daily': {'name': 'Item Daily Uses'}
   };
 
   static EFFECT = {

--- a/module/powerrolls/resource.js
+++ b/module/powerrolls/resource.js
@@ -3,11 +3,12 @@ import { Config } from '../config.js';
 export class PowerRollResource4e {
   static getMatch(withoutBrackets) {
     const resources = `(?<resourceTxt>${Object.keys(Config.RESOURCE).join('|')})`;
-    const resourceRgx = new RegExp(`^\\s*${resources}\\s*(?<digitTxt>\\d+)\\s*$`, 'i');
+    const resourceRgx = new RegExp(`^\\s*${resources}\\s*(?<digitTxt>\\d*)\\s*$`, 'i');
     return withoutBrackets.match(resourceRgx);
   }
 
   static _createPowerRollResource(withoutBrackets, {resourceTxt, digitTxt}, replacementTxt) {
+    digitTxt = digitTxt || '1';
     const resourceKey = Object.keys(Config.RESOURCE).filter(rgxKey => resourceTxt.match(new RegExp(`^${rgxKey}$`, 'i')))[0];
     const resource = Config.RESOURCE[resourceKey].name;
     const amount = Number(digitTxt);


### PR DESCRIPTION
It is now possible to create a Power Roll with no cost listed. It will default to 1. `[[/p Augment 1]]` is equivalent to `[[/p Augment]]`.

Also two more resources were added
`[[/p Channel Divinity]]` will use the `Channel Divinity` resource.
`[[/p Power * Daily]]` will use the `Item Daily Uses` resource.