### PR TITLE
Fixing Breaking changes with removal of word Beta.

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -104,13 +104,13 @@ export class Config {
   };
 
   static DURATION_LABEL = {
-    'saveEnd': "DND4EBETA.DurationSaveEnd",
-    'endOfEncounter': "DND4EBETA.DurationEndOfEnc",
-    'endOfDay': "DND4EBETA.DurationEndOfDay",
-    'endOfUserTurn': "DND4EBETA.DurationEndOfUserTurn",
-    'endOfTargetTurn': "DND4EBETA.DurationEndOfTargetTurnSimp",
-    'startOfUserTurn': "DND4EBETA.DurationStartOfUserTurn",
-    'startOfTargetTurn': "DND4EBETA.DurationStartOfTargetTurnSimp"
+    'saveEnd': "DND4E.DurationSaveEnd",
+    'endOfEncounter': "DND4E.DurationEndOfEnc",
+    'endOfDay': "DND4E.DurationEndOfDay",
+    'endOfUserTurn': "DND4E.DurationEndOfUserTurn",
+    'endOfTargetTurn': "DND4E.DurationEndOfTargetTurnSimp",
+    'startOfUserTurn': "DND4E.DurationStartOfUserTurn",
+    'startOfTargetTurn': "DND4E.DurationStartOfTargetTurnSimp"
   };
 
   static COMMON_EFFECTS = {

--- a/module/config.js
+++ b/module/config.js
@@ -103,7 +103,8 @@ export class Config {
     '(?:until|)\\s*(?:the|)\\s*start\\s*of\\s*.*\\s*next\\s*turn': {'durationType': 'startOfUserTurn', 'altDurationType': 'startOfTargetTurn', 'endsOnInit': 'TRUE'},
   };
 
-  static DURATION_LABEL = {
+  //Check the current system version as the namespace changes in 0.4.44 to remove the word BETA
+  static DURATION_LABEL = isNewerVersion(game.system.version, "0.4.43") ? {
     'saveEnd': "DND4E.DurationSaveEnd",
     'endOfEncounter': "DND4E.DurationEndOfEnc",
     'endOfDay': "DND4E.DurationEndOfDay",
@@ -111,6 +112,14 @@ export class Config {
     'endOfTargetTurn': "DND4E.DurationEndOfTargetTurnSimp",
     'startOfUserTurn': "DND4E.DurationStartOfUserTurn",
     'startOfTargetTurn': "DND4E.DurationStartOfTargetTurnSimp"
+  } : {
+    'saveEnd': "DND4EBETA.DurationSaveEnd",
+    'endOfEncounter': "DND4EBETA.DurationEndOfEnc",
+    'endOfDay': "DND4EBETA.DurationEndOfDay",
+    'endOfUserTurn': "DND4EBETA.DurationEndOfUserTurn",
+    'endOfTargetTurn': "DND4EBETA.DurationEndOfTargetTurnSimp",
+    'startOfUserTurn': "DND4EBETA.DurationStartOfUserTurn",
+    'startOfTargetTurn': "DND4EBETA.DurationStartOfTargetTurnSimp"
   };
 
   static COMMON_EFFECTS = {

--- a/module/config.js
+++ b/module/config.js
@@ -103,23 +103,15 @@ export class Config {
     '(?:until|)\\s*(?:the|)\\s*start\\s*of\\s*.*\\s*next\\s*turn': {'durationType': 'startOfUserTurn', 'altDurationType': 'startOfTargetTurn', 'endsOnInit': 'TRUE'},
   };
 
-  //Check the current system version as the namespace changes in 0.4.44 to remove the word BETA
-  static DURATION_LABEL = isNewerVersion(game.system.version, "0.4.43") ? {
-    'saveEnd': "DND4E.DurationSaveEnd",
-    'endOfEncounter': "DND4E.DurationEndOfEnc",
-    'endOfDay': "DND4E.DurationEndOfDay",
-    'endOfUserTurn': "DND4E.DurationEndOfUserTurn",
-    'endOfTargetTurn': "DND4E.DurationEndOfTargetTurnSimp",
-    'startOfUserTurn': "DND4E.DurationStartOfUserTurn",
-    'startOfTargetTurn': "DND4E.DurationStartOfTargetTurnSimp"
-  } : {
-    'saveEnd': "DND4EBETA.DurationSaveEnd",
-    'endOfEncounter': "DND4EBETA.DurationEndOfEnc",
-    'endOfDay': "DND4EBETA.DurationEndOfDay",
-    'endOfUserTurn': "DND4EBETA.DurationEndOfUserTurn",
-    'endOfTargetTurn': "DND4EBETA.DurationEndOfTargetTurnSimp",
-    'startOfUserTurn': "DND4EBETA.DurationStartOfUserTurn",
-    'startOfTargetTurn': "DND4EBETA.DurationStartOfTargetTurnSimp"
+  //Before calling check the current system version as the namespace changes in 0.4.44 to remove the word BETA
+  static DURATION_LABEL = {
+    'saveEnd': "DurationSaveEnd",
+    'endOfEncounter': "DurationEndOfEnc",
+    'endOfDay': "DurationEndOfDay",
+    'endOfUserTurn': "DurationEndOfUserTurn",
+    'endOfTargetTurn': "DurationEndOfTargetTurnSimp",
+    'startOfUserTurn': "DurationStartOfUserTurn",
+    'startOfTargetTurn': "DurationStartOfTargetTurnSimp"
   };
 
   static COMMON_EFFECTS = {

--- a/module/inkpot.js
+++ b/module/inkpot.js
@@ -11,7 +11,9 @@ Hooks.once('init', async function() {
     html.on('click', 'a.power-roll', event => {
       const button = event.currentTarget;
       const card = button.closest(".chat-card");
-      const actor = card ? game.dnd4e.entities.Item4e._getChatCardActor(card) : undefined;
+      //Check the current system version as the namespace changes in 0.4.44 to remove the word Beta
+      const namespace = isNewerVersion(game.system.version, "0.4.43") ? "dnd4e" : "dnd4eBeta";
+      const actor = card ? game[namespace].entities.Item4e._getChatCardActor(card) : undefined;
       const item = actor ? actor.items.get(card.dataset.itemId) : undefined;
       PowerRoll4e.onPowerRoll(event, actor, item, item || actor);
     });

--- a/module/inkpot.js
+++ b/module/inkpot.js
@@ -11,7 +11,7 @@ Hooks.once('init', async function() {
     html.on('click', 'a.power-roll', event => {
       const button = event.currentTarget;
       const card = button.closest(".chat-card");
-      const actor = card ? game.dnd4eBeta.entities.Item4e._getChatCardActor(card) : undefined;
+      const actor = card ? game.dnd4e.entities.Item4e._getChatCardActor(card) : undefined;
       const item = actor ? actor.items.get(card.dataset.itemId) : undefined;
       PowerRoll4e.onPowerRoll(event, actor, item, item || actor);
     });

--- a/module/powerroll4e.js
+++ b/module/powerroll4e.js
@@ -79,7 +79,9 @@ export class PowerRoll4e {
     if (!inputActor) {
       actors = canvas.tokens.controlled.map(x => x.actor);
       if (!actors.length) {
-        actors = [new game.dnd4e.entities.Actor4e({'name': 'PowerRoll', 'type': 'NPC'})];
+        //Check the current system version as the namespace changes in 0.4.44 to remove the word Beta
+        const namespace = isNewerVersion(game.system.version, "0.4.43") ? "dnd4e" : "dnd4eBeta";
+        actors = [new game[namespace].entities.Actor4e({'name': 'PowerRoll', 'type': 'NPC'})];
         emptyActor = true;
       }
     } else {
@@ -113,7 +115,9 @@ export class PowerRoll4e {
 
     const dataset = button.dataset;
     for (let actor of actors) {
-      const item = new game.dnd4e.entities.Item4e(itemData, {'parent': actor});
+      //Check the current system version as the namespace changes in 0.4.44 to remove the word Beta
+      const namespace = isNewerVersion(game.system.version, "0.4.43") ? "dnd4e" : "dnd4eBeta";
+      const item = new game[namespace].entities.Item4e(itemData, {'parent': actor});
       if ( action === "attack" ) await item.rollAttack({event});
       else if ( action === "damage" ) await item.rollDamage({event});
       else if ( action === "resource" ) PowerRollResource4e._spendResource(actor, dataset, emptyActor);

--- a/module/powerroll4e.js
+++ b/module/powerroll4e.js
@@ -79,7 +79,7 @@ export class PowerRoll4e {
     if (!inputActor) {
       actors = canvas.tokens.controlled.map(x => x.actor);
       if (!actors.length) {
-        actors = [new game.dnd4eBeta.entities.Actor4e({'name': 'PowerRoll', 'type': 'NPC'})];
+        actors = [new game.dnd4e.entities.Actor4e({'name': 'PowerRoll', 'type': 'NPC'})];
         emptyActor = true;
       }
     } else {
@@ -113,7 +113,7 @@ export class PowerRoll4e {
 
     const dataset = button.dataset;
     for (let actor of actors) {
-      const item = new game.dnd4eBeta.entities.Item4e(itemData, {'parent': actor});
+      const item = new game.dnd4e.entities.Item4e(itemData, {'parent': actor});
       if ( action === "attack" ) await item.rollAttack({event});
       else if ( action === "damage" ) await item.rollDamage({event});
       else if ( action === "resource" ) PowerRollResource4e._spendResource(actor, dataset, emptyActor);

--- a/module/powerrolls/effect.js
+++ b/module/powerrolls/effect.js
@@ -85,7 +85,7 @@ export class PowerRollEffect4e {
         "duration.startRound": startRound,
         "duration.startTime": 0,
         "duration.startTurn": startTurn,
-        "duration.label": game.i18n.localize(isNewerVersion(game.system.version, "0.4.43") ? "DND4E" : "DND4EBETA" + Config.DURATION_LABEL[durationType]),
+        "duration.label": game.i18n.localize(isNewerVersion(game.system.version, "0.4.43") ? "DND4E." : "DND4EBETA." + Config.DURATION_LABEL[durationType]),
         "disabled": false,
         "flags.dnd4e.effectData.durationType": durationType,
         "flags.dnd4e.effectData.startTurnInit": startTurnInit,

--- a/module/powerrolls/effect.js
+++ b/module/powerrolls/effect.js
@@ -85,7 +85,7 @@ export class PowerRollEffect4e {
         "duration.startRound": startRound,
         "duration.startTime": 0,
         "duration.startTurn": startTurn,
-        "duration.label": game.i18n.localize(Config.DURATION_LABEL[durationType]),
+        "duration.label": game.i18n.localize(isNewerVersion(game.system.version, "0.4.43") ? "DND4E" : "DND4EBETA" + Config.DURATION_LABEL[durationType]),
         "disabled": false,
         "flags.dnd4e.effectData.durationType": durationType,
         "flags.dnd4e.effectData.startTurnInit": startTurnInit,


### PR DESCRIPTION
Sorry I accidently broke support for your module with the last patch, where I changed some name spaces around to remove the word Beta when I changed `dnd4eBeta` to `dnd4e` and `DND4EBETA` to `DND4E`.

Just a pull request that fixes the brake as of the Foundry DnD4e System update v0.4.44.