### PR TITLE
Remove `@dmgMod` and `@atkMod` from formulas

### DIFF
--- a/module/powerrolls/attack.js
+++ b/module/powerrolls/attack.js
@@ -13,7 +13,7 @@ export class PowerRollAttack4e {
   static _createPowerRollAttack(withoutBrackets, {atkTxt, defTxt, wpnTxt}, replacementTxt) {
     let { parsedForm, formula } = PowerRollUtils4e.parseFormula(atkTxt);
     if (parsedForm.some(data => data.data.type == Config.TYPES.ABILITY)) formula += '+@lvhalf';
-    formula += '+@atkMod+@wepAttack';
+    formula += '@wepAttack';
 
     const parsedDef = PowerRollUtils4e._toParsedData(defTxt, '{}', Config.DEFENSE);
     const def = parsedDef[0].data.form;

--- a/module/powerrolls/attack.js
+++ b/module/powerrolls/attack.js
@@ -13,7 +13,7 @@ export class PowerRollAttack4e {
   static _createPowerRollAttack(withoutBrackets, {atkTxt, defTxt, wpnTxt}, replacementTxt) {
     let { parsedForm, formula } = PowerRollUtils4e.parseFormula(atkTxt);
     if (parsedForm.some(data => data.data.type == Config.TYPES.ABILITY)) formula += '+@lvhalf';
-    formula += '@wepAttack';
+    formula += '+@wepAttack';
 
     const parsedDef = PowerRollUtils4e._toParsedData(defTxt, '{}', Config.DEFENSE);
     const def = parsedDef[0].data.form;

--- a/module/powerrolls/damage.js
+++ b/module/powerrolls/damage.js
@@ -24,8 +24,6 @@ export class PowerRollDamage4e {
                       .filter(baseQuantity => baseQuantity);
     if(weapons.length > 1) ui.notifications.warn(`Too many weapons in: ${withoutBrackets}`);
     const baseQuantity = weapons[0] || "";
-    formula += '+@dmgMod';
-    crit += '+@dmgMod';
     const damageType = Config.DAMAGE_TYPES
                         .filter(dmgType => typeTxt.match(new RegExp(dmgType, 'i')))
                         .reduce((obj, dmgType) => ({ ...obj, [dmgType]: true}), {});

--- a/styles/inkpot.css
+++ b/styles/inkpot.css
@@ -1,3 +1,4 @@
 .power-roll {
   text-decoration: underline;
+  text-indent: 0;
 }


### PR DESCRIPTION
The `@dmgMod` and `@atkMod` have been deprecated in a recent update of the 4e system and should no longer be added to damage formulas. Updated relevant sections to reflect this change.