### PR TITLE
Fix for v13 - Update inkpot.js

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,9 +1,9 @@
 {
   "title": "Ink Pot - Power Roll",
   "description": "A module that allows inline rolling of D&amp;D 4e power attacks, damage, and resource spending.",
-  "url": "https://github.com/kyleady/inkpot-powerroll",
-  "manifest": "https://github.com/kyleady/inkpot-powerroll/releases/latest/download/module.json",
-  "download": "https://github.com/kyleady/inkpot-powerroll/releases/latest/download/module.zip",
+  "url": "https://github.com/d27182e/inkpot-powerroll",
+  "manifest": "https://github.com/d27182e/inkpot-powerroll/releases/latest/download/module.json",
+  "download": "https://github.com/d27182e/inkpot-powerroll/releases/latest/download/module.zip",
   "esmodules": [
     "module/inkpot.js"
   ],
@@ -21,7 +21,7 @@
   "styles": [
     "styles/inkpot.css"
   ],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "id": "inkpot-powerroll",
   "authors": [
     {
@@ -39,8 +39,8 @@
     ]
   },
   "compatibility": {
-    "minimum": "10",
-    "verified": "10"
+    "minimum": "13",
+    "verified": "13"
   },
   "socket": true
 }

--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
   "styles": [
     "styles/inkpot.css"
   ],
-  "version": "1.3.2",
+  "version": "1.3.3",
   "id": "inkpot-powerroll",
   "authors": [
     {

--- a/module/inkpot.js
+++ b/module/inkpot.js
@@ -24,7 +24,7 @@ Hooks.once('init', async function() {
   Hooks.on("renderActorSheet4e", (app, html, data) => {
 	var jhtml = $(app.element);
     jhtml.on('click', 'a.power-roll', event => {
-      const actor = app.object;
+      const actor = app.actor;
       const itemId = event.currentTarget.closest(".item")?.dataset?.itemId;
       const item = itemId ? actor.items.get(itemId) : undefined;
       PowerRoll4e.onPowerRoll(event, actor, item, item || actor);
@@ -35,14 +35,14 @@ Hooks.once('init', async function() {
   Hooks.on("renderItemSheet4e", (app, html, data) => {
 	var jhtml = $(app.element);
     jhtml.on('click', 'a.power-roll', event => {
-      const item = app.object;
-      const actor = item.parent;
-      PowerRoll4e.onPowerRoll(event, actor, item, item);
+	  const item = app.document;
+	  const actor = app.actor;
+      PowerRoll4e.onPowerRoll(event, actor, item, item || actor);
     });
   });
 
   //Handle power rolls when clicked inside a Journal.
-  Hooks.on("renderJournalSheet", (app, html, data) => {
+  Hooks.on("renderJournalEntryPageSheet", (app, html, data) => {
 	var jhtml = $(app.element);
     jhtml.on('click', 'a.power-roll', event => {
       PowerRoll4e.onPowerRoll(event, undefined, undefined, app);

--- a/module/inkpot.js
+++ b/module/inkpot.js
@@ -8,7 +8,8 @@ Hooks.once('init', async function() {
 
   //Handle power rolls when clicked inside the chat log.
   Hooks.on("renderChatLog", (app, html, data) => {
-    html.on('click', 'a.power-roll', event => {
+	var jhtml = $(app.element);
+    jhtml.on('click', 'a.power-roll', event => {
       const button = event.currentTarget;
       const card = button.closest(".chat-card");
       //Check the current system version as the namespace changes in 0.4.44 to remove the word Beta
@@ -21,7 +22,8 @@ Hooks.once('init', async function() {
 
   //Handle power rolls when clicked inside an Actor Sheet.
   Hooks.on("renderActorSheet4e", (app, html, data) => {
-    html.on('click', 'a.power-roll', event => {
+	var jhtml = $(app.element);
+    jhtml.on('click', 'a.power-roll', event => {
       const actor = app.object;
       const itemId = event.currentTarget.closest(".item")?.dataset?.itemId;
       const item = itemId ? actor.items.get(itemId) : undefined;
@@ -31,7 +33,8 @@ Hooks.once('init', async function() {
 
   //Handle power rolls when clicked inside an Item Sheet.
   Hooks.on("renderItemSheet4e", (app, html, data) => {
-    html.on('click', 'a.power-roll', event => {
+	var jhtml = $(app.element);
+    jhtml.on('click', 'a.power-roll', event => {
       const item = app.object;
       const actor = item.parent;
       PowerRoll4e.onPowerRoll(event, actor, item, item);
@@ -40,7 +43,8 @@ Hooks.once('init', async function() {
 
   //Handle power rolls when clicked inside a Journal.
   Hooks.on("renderJournalSheet", (app, html, data) => {
-    html.on('click', 'a.power-roll', event => {
+	var jhtml = $(app.element);
+    jhtml.on('click', 'a.power-roll', event => {
       PowerRoll4e.onPowerRoll(event, undefined, undefined, app);
     });
   });

--- a/module/powerrolls/attack.js
+++ b/module/powerrolls/attack.js
@@ -13,7 +13,7 @@ export class PowerRollAttack4e {
   static _createPowerRollAttack(withoutBrackets, {atkTxt, defTxt, wpnTxt}, replacementTxt) {
     let { parsedForm, formula } = PowerRollUtils4e.parseFormula(atkTxt);
     if (parsedForm.some(data => data.data.type == Config.TYPES.ABILITY)) formula += '+@lvhalf';
-    formula += '+@atkMod+@wepAttack';
+    formula += '+@wepAttack';
 
     const parsedDef = PowerRollUtils4e._toParsedData(defTxt, '{}', Config.DEFENSE);
     const def = parsedDef[0].data.form;

--- a/module/powerrolls/damage.js
+++ b/module/powerrolls/damage.js
@@ -24,8 +24,6 @@ export class PowerRollDamage4e {
                       .filter(baseQuantity => baseQuantity);
     if(weapons.length > 1) ui.notifications.warn(`Too many weapons in: ${withoutBrackets}`);
     const baseQuantity = weapons[0] || "";
-    formula += '+@dmgMod';
-    crit += '+@dmgMod';
     const damageType = Config.DAMAGE_TYPES
                         .filter(dmgType => typeTxt.match(new RegExp(dmgType, 'i')))
                         .reduce((obj, dmgType) => ({ ...obj, [dmgType]: true}), {});

--- a/styles/inkpot.css
+++ b/styles/inkpot.css
@@ -1,3 +1,4 @@
 .power-roll {
   text-decoration: underline;
+  text-indent: 0;
 }


### PR DESCRIPTION
Power Roll links weren't working in v13 because of the change to Application v2. Used the direct equivalent to the previous functions.

I also included all of the changes from https://github.com/kyleady/inkpot-powerroll/pull/9.